### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "ms": "^2.1.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0"",
-    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0"",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@temporalio/client": "^1.8.0",
     "@temporalio/worker": "^1.8.0",
     "@temporalio/workflow": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@temporalio/client": "^1.8.0",
-    "@temporalio/worker": "^1.8.0",
-    "@temporalio/workflow": "^1.8.0",
+    "@temporalio/client": "^1.11.7",
+    "@temporalio/worker": "^1.11.7",
+    "@temporalio/workflow": "^1.11.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "@temporalio/client": "^1.8.0",
     "@temporalio/worker": "^1.8.0",
     "@temporalio/workflow": "^1.8.0",
-    "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.0.0"
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.8",
@@ -76,8 +76,6 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
-    "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "ms": "^2.1.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0"",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0"",
     "@temporalio/client": "^1.8.0",
     "@temporalio/worker": "^1.8.0",
     "@temporalio/workflow": "^1.8.0",


### PR DESCRIPTION
Hello.

Thanks for the great work!

Could you please update nestjs and temporal dependencies so that we can work with the latest version? 

It all seems to work for me after this minor change `require.resolve('./workflows/index')`:

````
TemporalModule.register({
            connection: {
                address: 'localhost:7233',
                namespace: 'default',
            },
            taskQueue: 'my-task-queue',
            worker: {
                workflowsPath: require.resolve('./workflows/index'),
                activityClasses: [...],
                autoStart: true,
            },
            isGlobal: true,
        }),
````
