### PR TITLE
feat: Timeout options not being passed to Temporal SDK

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@ export { Worker } from '@temporalio/worker';
 import { Type } from '@nestjs/common';
 import { ScheduleClient, ScheduleHandle } from '@temporalio/client';
 import { NativeConnection, Worker } from '@temporalio/worker';
-import { TypedSearchAttributes } from '@temporalio/common';
+import { Duration, TypedSearchAttributes } from '@temporalio/common';
 import { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
 
 /**
@@ -1039,6 +1039,9 @@ export interface ScheduleAction {
     args?: unknown[];
     taskQueue: string;
     workflowId?: string;
+    workflowExecutionTimeout?: Duration;
+    workflowRunTimeout?: Duration;
+    workflowTaskTimeout?: Duration;
 }
 
 /**
@@ -1079,9 +1082,9 @@ export interface WorkflowStartOptions {
     searchAttributes?: TypedSearchAttributes;
     memo?: Record<string, string | number | boolean | object>;
     workflowIdReusePolicy?: 'ALLOW_DUPLICATE' | 'ALLOW_DUPLICATE_FAILED_ONLY' | 'REJECT_DUPLICATE';
-    workflowExecutionTimeout?: string;
-    workflowRunTimeout?: string;
-    workflowTaskTimeout?: string;
+    workflowExecutionTimeout?: Duration;
+    workflowRunTimeout?: Duration;
+    workflowTaskTimeout?: Duration;
 }
 
 /**
@@ -1591,9 +1594,9 @@ export interface ScheduleClientInitResult {
 export interface ScheduleWorkflowOptions {
     taskQueue?: string;
     workflowId?: string;
-    workflowExecutionTimeout?: string;
-    workflowRunTimeout?: string;
-    workflowTaskTimeout?: string;
+    workflowExecutionTimeout?: Duration;
+    workflowRunTimeout?: Duration;
+    workflowTaskTimeout?: Duration;
     retryPolicy?: Record<string, unknown>;
     args?: unknown[];
 }
@@ -1635,9 +1638,9 @@ export interface ScheduleWorkflowAction {
     taskQueue: string;
     args?: unknown[];
     workflowId?: string;
-    workflowExecutionTimeout?: string;
-    workflowRunTimeout?: string;
-    workflowTaskTimeout?: string;
+    workflowExecutionTimeout?: Duration;
+    workflowRunTimeout?: Duration;
+    workflowTaskTimeout?: Duration;
     retryPolicy?: Record<string, unknown>;
 }
 

--- a/src/services/temporal-schedule.service.ts
+++ b/src/services/temporal-schedule.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Inject } from '@nestjs/common';
 import { DiscoveryService } from '@nestjs/core';
 import { ScheduleClient, ScheduleHandle } from '@temporalio/client';
+import { Duration } from '@temporalio/common';
 import { TEMPORAL_MODULE_OPTIONS, TEMPORAL_CLIENT } from '../constants';
 import {
     TemporalOptions,
@@ -329,15 +330,16 @@ export class TemporalScheduleService implements OnModuleInit, OnModuleDestroy {
         }
 
         if (scheduleMetadata.workflowExecutionTimeout) {
-            options.workflowExecutionTimeout = scheduleMetadata.workflowExecutionTimeout as string;
+            options.workflowExecutionTimeout =
+                scheduleMetadata.workflowExecutionTimeout as Duration;
         }
 
         if (scheduleMetadata.workflowRunTimeout) {
-            options.workflowRunTimeout = scheduleMetadata.workflowRunTimeout as string;
+            options.workflowRunTimeout = scheduleMetadata.workflowRunTimeout as Duration;
         }
 
         if (scheduleMetadata.workflowTaskTimeout) {
-            options.workflowTaskTimeout = scheduleMetadata.workflowTaskTimeout as string;
+            options.workflowTaskTimeout = scheduleMetadata.workflowTaskTimeout as Duration;
         }
 
         if (scheduleMetadata.retryPolicy) {

--- a/test/unit/temporal-client.service.spec.ts
+++ b/test/unit/temporal-client.service.spec.ts
@@ -296,6 +296,52 @@ describe('TemporalClientService', () => {
             expect(result.handle).toBe(mockWorkflowHandle);
         });
 
+        it('should pass timeout options to workflow start', async () => {
+            const workflowType = 'testWorkflow';
+            const args = [{ data: 'test' }];
+            const options = {
+                workflowId: 'custom-id',
+                taskQueue: 'custom-queue',
+                workflowExecutionTimeout: '1h',
+                workflowRunTimeout: '30m',
+                workflowTaskTimeout: '10s',
+            };
+
+            await service.startWorkflow(workflowType, args, options);
+
+            expect(mockClient.workflow!.start).toHaveBeenCalledWith(workflowType, {
+                workflowId: 'custom-id',
+                taskQueue: 'custom-queue',
+                args,
+                workflowExecutionTimeout: '1h',
+                workflowRunTimeout: '30m',
+                workflowTaskTimeout: '10s',
+            });
+        });
+
+        it('should pass other workflow options (searchAttributes, memo, workflowIdReusePolicy)', async () => {
+            const workflowType = 'testWorkflow';
+            const args = [{ data: 'test' }];
+            const options = {
+                workflowId: 'custom-id',
+                taskQueue: 'custom-queue',
+                searchAttributes: { customAttr: 'value' },
+                memo: { note: 'test memo' },
+                workflowIdReusePolicy: 'REJECT_DUPLICATE' as const,
+            };
+
+            await service.startWorkflow(workflowType, args, options);
+
+            expect(mockClient.workflow!.start).toHaveBeenCalledWith(workflowType, {
+                workflowId: 'custom-id',
+                taskQueue: 'custom-queue',
+                args,
+                typedSearchAttributes: { customAttr: 'value' },
+                memo: { note: 'test memo' },
+                workflowIdReusePolicy: 'REJECT_DUPLICATE',
+            });
+        });
+
         it('should generate workflow ID if not provided', async () => {
             await service.startWorkflow('testWorkflow');
 
@@ -476,31 +522,41 @@ describe('TemporalClientService', () => {
             it('should reject workflow ID with newline characters', async () => {
                 await expect(
                     service.startWorkflow('testWorkflow', [], { workflowId: 'test\nid' }),
-                ).rejects.toThrow('Workflow ID cannot contain newlines, tabs, or control characters');
+                ).rejects.toThrow(
+                    'Workflow ID cannot contain newlines, tabs, or control characters',
+                );
             });
 
             it('should reject workflow ID with carriage return characters', async () => {
                 await expect(
                     service.startWorkflow('testWorkflow', [], { workflowId: 'test\rid' }),
-                ).rejects.toThrow('Workflow ID cannot contain newlines, tabs, or control characters');
+                ).rejects.toThrow(
+                    'Workflow ID cannot contain newlines, tabs, or control characters',
+                );
             });
 
             it('should reject workflow ID with tab characters', async () => {
                 await expect(
                     service.startWorkflow('testWorkflow', [], { workflowId: 'test\tid' }),
-                ).rejects.toThrow('Workflow ID cannot contain newlines, tabs, or control characters');
+                ).rejects.toThrow(
+                    'Workflow ID cannot contain newlines, tabs, or control characters',
+                );
             });
 
             it('should reject workflow ID with null character', async () => {
                 await expect(
                     service.startWorkflow('testWorkflow', [], { workflowId: 'test\u0000id' }),
-                ).rejects.toThrow('Workflow ID cannot contain newlines, tabs, or control characters');
+                ).rejects.toThrow(
+                    'Workflow ID cannot contain newlines, tabs, or control characters',
+                );
             });
 
             it('should reject workflow ID with other control characters', async () => {
                 await expect(
                     service.startWorkflow('testWorkflow', [], { workflowId: 'test\u0001id' }),
-                ).rejects.toThrow('Workflow ID cannot contain newlines, tabs, or control characters');
+                ).rejects.toThrow(
+                    'Workflow ID cannot contain newlines, tabs, or control characters',
+                );
             });
 
             it('should accept workflow ID with valid special characters', async () => {
@@ -653,10 +709,7 @@ describe('TemporalClientService', () => {
 
             await expect(service.terminateWorkflow('test-id', 'reason')).rejects.toThrow();
 
-            expect(logSpy).toHaveBeenCalledWith(
-                "Failed to terminate workflow 'test-id'",
-                error,
-            );
+            expect(logSpy).toHaveBeenCalledWith("Failed to terminate workflow 'test-id'", error);
 
             logSpy.mockRestore();
         });
@@ -710,10 +763,7 @@ describe('TemporalClientService', () => {
 
             await expect(service.cancelWorkflow('test-id')).rejects.toThrow();
 
-            expect(logSpy).toHaveBeenCalledWith(
-                "Failed to cancel workflow 'test-id'",
-                error,
-            );
+            expect(logSpy).toHaveBeenCalledWith("Failed to cancel workflow 'test-id'", error);
 
             logSpy.mockRestore();
         });
@@ -1492,9 +1542,7 @@ describe('TemporalClientService', () => {
 
             await service.startWorkflow('testWorkflow');
 
-            expect(debugSpy).toHaveBeenCalledWith(
-                'Performing health check before retry attempt 2',
-            );
+            expect(debugSpy).toHaveBeenCalledWith('Performing health check before retry attempt 2');
 
             debugSpy.mockRestore();
         });


### PR DESCRIPTION
## Fix: Timeout options not being passed to Temporal SDK

**Problem:** `workflowExecutionTimeout`, `workflowRunTimeout`, and `workflowTaskTimeout` options were not being passed to the SDK in `startWorkflow` and `createSchedule` methods.

**Solution:**
- Pass timeout options to SDK in `startWorkflow` and `createSchedule`
- Update interfaces to use `Duration` type (`string | number`) for consistency
- Replace deprecated `searchAttributes` with `typedSearchAttributes`
- Add test examples

**Files changed:**
- `src/services/temporal-client.service.ts`
- `src/services/temporal-schedule.service.ts`
- `src/interfaces.ts`

**Breaking changes:** None

<img width="805" height="316" alt="image" src="https://github.com/user-attachments/assets/3a1878db-6361-444a-85ff-3dbba32eb725" />
