### PR TITLE
feat: add support for missing schedule options (paused, overlapPolicy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 A comprehensive NestJS integration framework for Temporal.io that provides enterprise-ready workflow orchestration with automatic discovery, declarative decorators, and robust monitoring capabilities.
 
-![Statements](https://img.shields.io/badge/statements-99.8%25-brightgreen.svg?style=flat)
-![Branches](https://img.shields.io/badge/branches-92.2%25-brightgreen.svg?style=flat)
-![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat)
-![Lines](https://img.shields.io/badge/lines-99.79%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-Unknown%25-brightgreen.svg?style=flat)
+![Branches](https://img.shields.io/badge/branches-Unknown%25-brightgreen.svg?style=flat)
+![Functions](https://img.shields.io/badge/functions-Unknown%25-brightgreen.svg?style=flat)
+![Lines](https://img.shields.io/badge/lines-Unknown%25-brightgreen.svg?style=flat)
 
 [Documentation](https://harsh-simform.github.io/nestjs-temporal-core/) • [NPM](https://www.npmjs.com/package/nestjs-temporal-core) • [GitHub](https://github.com/harsh-simform/nestjs-temporal-core) • [Example Project](https://github.com/harsh-simform/nestjs-temporal-core-example)
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1045,35 +1045,6 @@ export interface ScheduleAction {
 }
 
 /**
- * Schedule creation options with required spec and action
- */
-export interface ScheduleCreateOptions {
-    scheduleId: string;
-    spec: ScheduleSpec;
-    action: ScheduleAction;
-    memo?: Record<string, string | number | boolean | object>;
-    searchAttributes?: Record<string, string | number | boolean | object>;
-    workflowType?: string;
-    args?: unknown[];
-    taskQueue?: string;
-    interval?: string | number;
-    cron?: string;
-    timezone?: string;
-    overlapPolicy?:
-        | 'skip'
-        | 'buffer_one'
-        | 'buffer_all'
-        | 'cancel_other'
-        | 'terminate_other'
-        | 'allow_all';
-    catchupWindow?: string | number;
-    pauseOnFailure?: boolean;
-    description?: string;
-    paused?: boolean;
-    limitedActions?: number;
-}
-
-/**
  * Workflow start options with proper typing
  */
 export interface WorkflowStartOptions {
@@ -1483,6 +1454,18 @@ export interface ScheduleCreationOptions {
     action: ScheduleAction;
     memo?: Record<string, unknown>;
     searchAttributes?: Record<string, unknown>;
+    paused?: boolean;
+    overlapPolicy?:
+        | 'skip'
+        | 'buffer_one'
+        | 'buffer_all'
+        | 'cancel_other'
+        | 'terminate_other'
+        | 'allow_all';
+    catchupWindow?: string | number;
+    pauseOnFailure?: boolean;
+    description?: string;
+    limitedActions?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds support for missing schedule options in `createSchedule` method and consolidates duplicate interfaces.

## Changes
- Add support for `paused` option (maps to `state.paused` in SDK)
- Add support for schedule policy options:
  - `overlapPolicy` (maps to `policies.overlap`, converts to uppercase)
  - `catchupWindow` (maps to `policies.catchupWindow`)
  - `pauseOnFailure` (maps to `policies.pauseOnFailure`)
- Add support for `description` and `limitedActions` options
- Remove unused `ScheduleCreateOptions` interface (consolidated into `ScheduleCreationOptions`)
- Transform the options structure correctly before passing to the Temporal SDK
- Update tests to verify new options are passed correctly

## Fixes
Previously, options like `paused` and `overlapPolicy` were not being passed to the Temporal SDK because they require a specific structure (`state.paused`, `policies.overlap`, etc.). This PR ensures all options are properly transformed and passed to the SDK.

@harsh-simform could you take a look at this PR?